### PR TITLE
Prevent images from being taller than 50% of the window

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -85,6 +85,7 @@ textarea.form__input,
 }
 img {
     max-width:100%;
+    max-height:50vh;
 }
 .chat-messages .whisper-line.whisper-incoming {
     background-color:#3b010e !important;


### PR DESCRIPTION
Tall images can fill the entire chat window -- that's probably not ideal.