### PR TITLE
Bring chat-header back in the viewer list, otherwise the list can't be closed

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -12,6 +12,9 @@ body {
 	font-size: 2rem !important;
 	background: black;
 }
+.chatters .chat-header {
+	display:block !important;
+}
 
 select.form__input,
 textarea.form__input,


### PR DESCRIPTION
If the chat input box is shown, it's possible to open the viewer list; with chat-header hidden, it can then never be closed.