### PR TITLE
Add support for Giphy, YouTube and Twitter

### DIFF
--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -254,7 +254,7 @@ function actionFunction() {
                                 var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
                                 $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
                             }
-                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)(.+)$/mg.exec($(this).text());
+                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&]+).*$/mg.exec($(this).text());
                             if (match) {
                                 var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
                                 $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -254,6 +254,11 @@ function actionFunction() {
                                 var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
                                 $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
                             }
+                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)(.+)$/mg.exec($(this).text());
+                            if (match) {
+                                var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
+                                $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
+                            }
                         });
                     }
 

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -110,6 +110,10 @@ var configFields = {
 
 initConfig();
 waitForKeyElements (".chat-lines", onChatLoad);
+var twitterScript = document.createElement("script");
+twitterScript.type = "text/javascript";
+twitterScript.src = "https://platform.twitter.com/widgets.js";
+document.body.appendChild(twitterScript);
 
 function onChatLoad() {
     loadSettings();
@@ -258,6 +262,16 @@ function actionFunction() {
                             if (match) {
                                 var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
                                 $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
+                            }
+                            match = /^https?:\/\/(www\.)?twitter\.com.+\/([0-9]+)$/mg.exec($(this).text());
+                            if (match) {
+                                var tweetContainer = document.createElement('div');
+                                this.parentNode.appendChild(tweetContainer);
+                                tweetContainer.style.display = 'none';
+                                twttr.widgets.createTweet(match[2], tweetContainer, { theme: 'dark', conversation: 'hidden', cards: 'hidden' }).then(el => {
+                                    tweetContainer.style.display = 'block';
+                                    // scrollReference = scrollDistance += el.scrollHeight; // to uncomment when merged with JavaScript scrolling
+                                }).catch(e => console.log(e));
                             }
                         });
                     }

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -258,7 +258,7 @@ function actionFunction() {
                                 var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
                                 $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
                             }
-                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&]+).*$/mg.exec($(this).text());
+                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&?]+).*$/mg.exec($(this).text());
                             if (match) {
                                 var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
                                 $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -247,7 +247,12 @@ function actionFunction() {
                         $links.each(function(i){
                             var re = /(.*(?:jpg|png|gif))$/mg;
                             if(re.test($(this).text())){
-                                $(this).html('<img src="'+$(this).text()+'" alt="'+$(this).text()+'"/>');
+                                $(this).html('<img src="'+$(this).text().replace("media.giphy.com", "media1.giphy.com")+'" alt="'+$(this).text()+'"/>');
+                            }
+                            var match = /^https?:\/\/giphy\.com\/gifs\/(.+)$/mg.exec($(this).text());
+                            if (match) {
+                                var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
+                                $(this).html('<img src="'+imageUrl+'" alt="'+imageUrl+'"/>');
                             }
                         });
                     }

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -276,36 +276,36 @@ function actionFunction() {
                         $node.attr('data-message',$node.find('.message').text().replace(/(\r|\s{2,})/gm," ").trim().toLowerCase());
 
 
-                    //add inline images
-                    if(inlineImages) {
-                        var $links = $node.find('.message a');
-                        $links.each(function(i){
-                            var re = /(.*(?:jpg|png|gif|jpeg))$/mg;
-                            if(re.test($(this).text())){
-                                $(this).html('<img src="'+$(this).text().replace("media.giphy.com", "media1.giphy.com")+'" alt="'+$(this).text()+'"/>');
-                            }
-                            var match = /^https?:\/\/giphy\.com\/gifs\/(.+)$/mg.exec($(this).text());
-                            if (match) {
-                                var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
-                                $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
-                            }
-                            match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&?]+).*$/mg.exec($(this).text());
-                            if (match) {
-                                var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
-                                $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
-                            }
-                            match = /^https?:\/\/(www\.)?twitter\.com.+\/([0-9]+)$/mg.exec($(this).text());
-                            if (match) {
-                                var tweetContainer = document.createElement('div');
-                                this.parentNode.appendChild(tweetContainer);
-                                tweetContainer.style.display = 'none';
-                                twttr.widgets.createTweet(match[2], tweetContainer, { theme: 'dark', conversation: 'hidden', cards: 'hidden' }).then(el => {
-                                    tweetContainer.style.display = 'block';
-                                    // scrollReference = scrollDistance += el.scrollHeight; // to uncomment when merged with JavaScript scrolling
-                                }).catch(e => console.log(e));
-                            }
-                        });
-                    }
+                        //add inline images
+                        if(inlineImages) {
+                            var $links = $node.find('.message a');
+                            $links.each(function(i){
+                                var re = /(.*(?:jpg|png|gif|jpeg))$/mg;
+                                if(re.test($(this).text())){
+                                    $(this).html('<img src="'+$(this).text().replace("media.giphy.com", "media1.giphy.com")+'" alt="'+$(this).text()+'"/>');
+                                }
+                                var match = /^https?:\/\/giphy\.com\/gifs\/(.+)$/mg.exec($(this).text());
+                                if (match) {
+                                    var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
+                                    $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
+                                }
+                                match = /^https?:\/\/(www\.)?(youtu\.be\/|youtube\.com\/watch\?v=)([^&?]+).*$/mg.exec($(this).text());
+                                if (match) {
+                                    var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
+                                    $(this).html($(this).text()+'<br/><img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
+                                }
+                                match = /^https?:\/\/(www\.)?twitter\.com.+\/([0-9]+)$/mg.exec($(this).text());
+                                if (match) {
+                                    var tweetContainer = document.createElement('div');
+                                    this.parentNode.appendChild(tweetContainer);
+                                    tweetContainer.style.display = 'none';
+                                    twttr.widgets.createTweet(match[2], tweetContainer, { theme: 'dark', conversation: 'hidden', cards: 'hidden' }).then(el => {
+                                        tweetContainer.style.display = 'block';
+                                        // scrollReference = scrollDistance += el.scrollHeight; // to uncomment when merged with JavaScript scrolling
+                                    }).catch(e => console.log(e));
+                                }
+                            });
+                        }
 
                         if (!$node.prev().hasClass("odd")) {
                             $node.addClass("odd");

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -252,7 +252,7 @@ function actionFunction() {
                             var match = /^https?:\/\/giphy\.com\/gifs\/(.+)$/mg.exec($(this).text());
                             if (match) {
                                 var imageUrl = "https://media1.giphy.com/media/" + match[1].split("-").pop() + "/giphy.gif";
-                                $(this).html('<img src="'+imageUrl+'" alt="'+imageUrl+'"/>');
+                                $(this).html('<img src="'+imageUrl+'" alt="'+$(this).text()+'"/>');
                             }
                         });
                     }

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -3,7 +3,7 @@
 // @namespace      http://somewhatnifty.com
 // @description    reformats twitch chat for display on a chat monitor
 // @match        https://www.twitch.tv/*/chat?display*
-// @version    0.204
+// @version    0.205
 // @updateURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/master/chat-monitor.js
 // @downloadURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/master/chat-monitor.js
 // @require  https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js


### PR DESCRIPTION
This commit converts the giphy links to the gif image so these can be shown as well. I suppose we don't want to start supporting all sorts of random services, but Giphy seems pretty big to me.

This commit may clash slightly with my other pull request that replaces the CSS animation with a JavaScript solution that scrolls the page as there are some whitespace differences. It should be fairly straightforward to merge them though.