### PR TITLE
Fixing the 'new-twitch' branch

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -5,7 +5,7 @@ body {
     font-family: 'Open Sans Condensed', sans-serif !important;
 }
 
-#root .chat-room__header, .chat-list__more-messages-placeholder {
+#root .chat-room__header, .chat-list__more-messages-placeholder, .pinned-cheer {
     display:none !important;
 }
 
@@ -25,7 +25,7 @@ body {
     font-size: 2.4rem !important;
 }
 
-.chat-list .full-height.reverse {
+.chat-list .tw-full-height.reverse {
     display:flex !important;
     flex-direction:column-reverse;
     padding-bottom:100vh !important;
@@ -35,7 +35,7 @@ body {
     top:0px !important;
     background-color:black !important;
 }
-.chat-list .full-height {
+.chat-list .tw-full-height {
     background-color:black !important;
     color:#eee;
     display: flex;
@@ -52,22 +52,24 @@ body {
     line-height:35px !important;
     border-bottom:#444 solid 1px !important;
 }
-/* TODO: Haven't encountered any clips yet */
-.chat-line__message .chat-clip {
+.chat-line__subscribe span {
+    color: white;
+}
+.chat-line__message .chat-card__link {
     background-color: #333 !important;
 }
-.chat-line__message .chat-chip .card__title {
+.chat-line__message .chat-card__link div {
     display: inline;
+}
+.chat-line__message .chat-card__link .chat-card__title span {
     font-size: 32px !important;
     line-height: 35px !important;
     color: white;
-    font-weight: 300;
 }
-.chat-line__message .chat-chip .card__info {
-    display: inline;
+.chat-line__message .chat-card__link .chat-card__title + div span {
     font-size: 32px !important;
     line-height: 35px !important;
-    color: #afabbc;
+    color: #bbb !important;
 }
 .special-message {
     background-color: inherit !important;

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -5,8 +5,8 @@
 // @match        https://www.twitch.tv/popout/*/chat?display*
 // @match        https://www.twitch.tv/*/chat?display*
 // @version    0.204
-// @updateURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/new-twitch/chat-monitor.js
-// @downloadURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/new-twitch/chat-monitor.js
+// @updateURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/new-twitch/chat-monitor.user.js
+// @downloadURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/new-twitch/chat-monitor.user.js
 // @require  https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js
 // @require  https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant       GM_getResourceText


### PR DESCRIPTION
These commits do the following:
- Fix the script so it generally works again with the changes that were made to the new Twitch chat layout
- Redirect to the new Twitch chat when opening the old chat (when using this branch, you should never look at that page)
- Rename the script so it ends with .user.js This is the naming convention for userscripts and will allow extensions to pick it up automatically when you load the source in the page
- I've added the image, YouTube link and Twitter link processing as is currently possible on the master branch
- The displaying of clips and subscription notifications should be good now

I also did some tests on my Raspberry Pi 3, but I can't say I'm noticing any big difference.
Known issues:
- Reversing the messages doesn't seem to work properly as the page always moves to the bottom (due to auto scroll by Twitch)
- Every once in a while the scroll goes to the bottom of the page, making the screen black. Not sure what's causing it yet