### PR TITLE
Small CSS changes + fix to black screen

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -46,7 +46,7 @@ body {
 .chat-line__message.odd {
     background-color:#111 !important;
 }
-.chat-line__message, .chat-line__status, .chat-line__subscribe {
+.chat-line__message, .chat-line__status, .chat-line__subscribe, .user-notice-line {
     padding:3px 1px 3px 6px !important;
     font-size:32px !important;
     line-height:35px !important;
@@ -70,6 +70,10 @@ body {
     font-size: 32px !important;
     line-height: 35px !important;
     color: #bbb !important;
+}
+.mention-fragment {
+    background-color: transparent !important;
+    padding: 0;
 }
 .special-message {
     background-color: inherit !important;
@@ -154,4 +158,3 @@ body .pinned-cheer-v2 {
 .scrollable-area .simplebar-track {
     display:none !important;
 }
-

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -343,12 +343,16 @@ function actionFunction() {
     // Continually scroll up, in a way to make the comments readable
     var lastFrame = +new Date();
     function scrollUp(now) {
-        if (GM_config.get("SmoothScroll") && GM_config.get("ReverseDirection") && scrollDistance > 0) {
-            // estimate how far along we are in scrolling in the current scroll reference
-            var currentStep = parseFloat(GM_config.get("SmoothScrollSpeed")) * 1000 / (now - lastFrame);
-            scrollDistance -= scrollReference / currentStep;
-            scrollDistance = Math.max(Math.floor(scrollDistance), 0);
-            chatContentDiv.scrollTop = scrollDistance;
+        if (chatContentDiv.scrollTop > 0 && GM_config.get("ReverseDirection")) {
+            if (scrollDistance > 0 && GM_config.get("SmoothScroll")) {
+                // estimate how far along we are in scrolling in the current scroll reference
+                var currentStep = parseFloat(GM_config.get("SmoothScrollSpeed")) * 1000 / (now - lastFrame);
+                scrollDistance -= scrollReference / currentStep;
+                scrollDistance = Math.max(Math.floor(scrollDistance), 0);
+                chatContentDiv.scrollTop = scrollDistance;
+            } else {
+                chatContentDiv.scrollTop = 0;
+            }
         }
         lastFrame = now;
         window.requestAnimationFrame(scrollUp);


### PR DESCRIPTION
The two commits below contain two changes to the CSS:

- The subscription message is readable again (the CSS class seems to have been changed)
- The special styling for mentions to other chat members has been removed

Additionally, the black screen that sometimes shows up at the start should no longer appear now. The page now continuously scrolls to the top. This has the advantage of always working, but the disadvantage that you can't scroll down manually on the page. But that didn't really work well in the past either, so that seems like an acceptable situation to me.
I've done some quick performance testing and the impact should be negligible due to some small optimizations. I didn't fire up the Raspberry Pi for this though.