### PR TITLE
Remove room header

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -5,7 +5,7 @@ body {
     font-family: 'Open Sans Condensed', sans-serif !important;
 }
 
-#root .chat-room__header, .chat-list__more-messages-placeholder, .pinned-cheer, .chat-room__notifications {
+#root .chat-room__header, .chat-list__more-messages-placeholder, .pinned-cheer, .chat-room__notifications, .rooms-header {
     display:none !important;
 }
 

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -4,7 +4,7 @@
 // @description    reformats twitch chat for display on a chat monitor
 // @match        https://www.twitch.tv/popout/*/chat?display*
 // @match        https://www.twitch.tv/*/chat?display*
-// @version    0.303
+// @version    0.304
 // @updateURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/master/chat-monitor.user.js
 // @downloadURL https://raw.githubusercontent.com/paul-lrr/nifty-chat-monitor/master/chat-monitor.user.js
 // @require  https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js


### PR DESCRIPTION
Hey Paul,

This is just a minor change to hide the newly added rooms header at the top of the popout chat.

FYI: I've been working on grouping messages together and it is generally working fine. There are still some rough edges I want to get rid of first though.

Kind regards,
Tom