### PR TITLE
Fix chat window when enabled

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -193,9 +193,6 @@ body .pinned-cheer-v2 {
   display: none !important;
 }
 
-body .tw-z-default {
-  display: none !important;
-}
 body .chat-list__list-footer {
   display: none !important;
 }


### PR DESCRIPTION
I removed those lines and the chat input area would work again when enabled. I tested it with and without the chat input area enabled and it didn't seem to affect anything else on the page. Also tested it with each font and saw no change.