### PR TITLE
Fix bugs with file ending capitalisation or trailing query strings resulting in images and tweets not being inlined

### DIFF
--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -326,7 +326,7 @@ function actionFunction() {
             //add inline images
             if (inlineImages) {
               newNode.querySelectorAll(".chat-line__message > a").forEach(function(link) {
-                var re = /.*(?:jpe?g|png|gif)$/gm;
+                var re = /.*(?:jpe?g|png|gif)$/gim;
                 if (re.test(link.textContent)) {
                   link.innerHTML =
                     '<img src="' + link.textContent.replace("media.giphy.com", "media1.giphy.com") + '" alt="' + link.textContent + '"/>';

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -326,7 +326,7 @@ function actionFunction() {
             //add inline images
             if (inlineImages) {
               newNode.querySelectorAll(".chat-line__message > a").forEach(function(link) {
-                var re = /.*(?:jpe?g|png|gif)$/gim;
+                var re = /.*(?:jpe?g|png|gif)(?:\?.*)?$/gim;
                 if (re.test(link.textContent)) {
                   link.innerHTML =
                     '<img src="' + link.textContent.replace("media.giphy.com", "media1.giphy.com") + '" alt="' + link.textContent + '"/>';
@@ -341,7 +341,7 @@ function actionFunction() {
                   var imageUrl = "https://img.youtube.com/vi/" + match[3] + "/mqdefault.jpg";
                   link.innerHTML = link.textContent + '<br/><img src="' + imageUrl + '" alt="' + link.textContent + '"/>';
                 }
-                match = /^https?:\/\/(www\.)?twitter\.com.+\/([0-9]+)$/gm.exec(link.textContent);
+                match = /^https?:\/\/(www\.)?twitter\.com.+\/([0-9]+)(?:\?.*)?$/gm.exec(link.textContent);
                 if (match) {
                   var tweetContainer = document.createElement("div");
                   link.parentNode.appendChild(tweetContainer);

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -326,7 +326,7 @@ function actionFunction() {
             //add inline images
             if (inlineImages) {
               newNode.querySelectorAll(".chat-line__message > a").forEach(function(link) {
-                var re = /(.*(?:jpg|png|gif|jpeg))$/gm;
+                var re = /.*(?:jpe?g|png|gif)$/gm;
                 if (re.test(link.textContent)) {
                   link.innerHTML =
                     '<img src="' + link.textContent.replace("media.giphy.com", "media1.giphy.com") + '" alt="' + link.textContent + '"/>';

--- a/chat-monitor.user.js
+++ b/chat-monitor.user.js
@@ -326,7 +326,7 @@ function actionFunction() {
             //add inline images
             if (inlineImages) {
               newNode.querySelectorAll(".chat-line__message > a").forEach(function(link) {
-                var re = /.*(?:jpe?g|png|gif)(?:\?.*)?$/gim;
+                var re = /.*\.(?:jpe?g|png|gif)(?:\?.*)?$/gim;
                 if (re.test(link.textContent)) {
                   link.innerHTML =
                     '<img src="' + link.textContent.replace("media.giphy.com", "media1.giphy.com") + '" alt="' + link.textContent + '"/>';


### PR DESCRIPTION
Image links with capitalised file endings (e.g. JPG) were not being inlined.
Image or tweet links with trailing query strings were not being inlined.
Image links were not required to have a period before the file ending.
All of these issues are resolved with these commits.

The version number will of course need to be bumped for these changes to be sent out to users.